### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/pnpm-build.yml
+++ b/.github/workflows/pnpm-build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - 'projects/popup-demo/**'
+      - 'projects/popup-ngx-query-builder/**'
+  pull_request:
+    paths:
+      - 'projects/popup-demo/**'
+      - 'projects/popup-ngx-query-builder/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `pnpm build` when demo or popup-ngx-query-builder projects change

## Testing
- `pnpm build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab666bd908321881ee095020f0dc4