### PR TITLE
Add named ruleset features to popup builder

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/query-input/edit-ruleset-dialog.component.ts
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/edit-ruleset-dialog.component.ts
@@ -1,0 +1,67 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { RuleSet } from 'ngx-query-builder';
+
+export interface EditRulesetDialogData {
+  ruleset: RuleSet;
+  rulesetName: string;
+  validate: (rs: any) => boolean;
+}
+
+@Component({
+  selector: 'lib-edit-ruleset-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatDialogModule],
+  template: `
+    <h1 mat-dialog-title>Edit {{data.rulesetName}}</h1>
+    <div mat-dialog-content>
+      <textarea class="dialog-output" [(ngModel)]="text" (ngModelChange)="onChange($event)"></textarea>
+    </div>
+    <div mat-dialog-actions>
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+      <button mat-raised-button color="primary" [disabled]="state !== 'valid'" (click)="save()">Save</button>
+    </div>
+  `,
+  styles: [
+    `.dialog-output { width: 100%; height: 100%; resize: none; box-sizing: border-box; }`
+  ]
+})
+export class EditRulesetDialogComponent {
+  text: string;
+  state: 'valid' | 'invalid-json' | 'invalid-query' = 'valid';
+
+  constructor(
+    public dialogRef: MatDialogRef<EditRulesetDialogComponent, RuleSet | null>,
+    @Inject(MAT_DIALOG_DATA) public data: EditRulesetDialogData
+  ) {
+    this.text = JSON.stringify(data.ruleset, null, 2);
+    this.validate();
+  }
+
+  onChange(value: string): void {
+    this.text = value;
+    this.validate();
+  }
+
+  private validate(): void {
+    try {
+      const val = JSON.parse(this.text.trim());
+      this.state = this.data.validate(val) ? 'valid' : 'invalid-query';
+    } catch {
+      this.state = 'invalid-json';
+    }
+  }
+
+  save(): void {
+    try {
+      const val = JSON.parse(this.text.trim());
+      if (this.data.validate(val)) {
+        this.dialogRef.close(val);
+      }
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -25,12 +25,14 @@
   styleClass="query-builder-dialog"
   [baseZIndex]="10000">
   
-  <ngx-query-builder 
-    [(ngModel)]="builderQuery" 
+  <ngx-query-builder
+    [(ngModel)]="builderQuery"
     [config]="queryBuilderConfig"
     [allowNot]="allowNot"
     [allowConvertToRuleset]="allowConvertToRuleset"
-    [allowRuleUpDown]="allowRuleUpDown"></ngx-query-builder>
+    [allowRuleUpDown]="allowRuleUpDown"
+    [ruleName]="ruleName"
+    [rulesetName]="rulesetName"></ngx-query-builder>
   
   <ng-template pTemplate="footer">
     <div class="dialog-footer">

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -1,3 +1,7 @@
+::ng-deep .cdk-overlay-container {
+  z-index: 11000 !important;
+}
+
 .query-input {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- enhance `query-input` to handle named rulesets
- provide dialog for editing rulesets
- show rule and ruleset names
- ensure material dialogs appear above popup

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run build:lib` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871a2a238d48321aa41f884e0c073b4