### PR TITLE
Fix overlay stacking for edit dialogs

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -1,5 +1,13 @@
+// Ensure Angular Material dialogs appear above the PrimeNG query builder dialog
+// by increasing the default overlay z-index. PrimeNG's dialog uses a base
+// z-index of 10000, so we push Material dialogs higher to keep them visible
+// and modal.
 ::ng-deep .cdk-overlay-container {
-  z-index: 11000 !important;
+  z-index: 20000 !important;
+}
+
+::ng-deep .cdk-overlay-backdrop {
+  z-index: 19999 !important;
 }
 
 .query-input {

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -7,7 +7,7 @@
 }
 
 ::ng-deep .cdk-overlay-backdrop {
-  z-index: 19999 !important;
+  z-index: 1000 !important;
 }
 
 .query-input {


### PR DESCRIPTION
## Summary
- ensure the Angular Material overlay is above the PrimeNG query builder dialog

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c3e702848321b88e225f50769950