### PR TITLE
Add named ruleset handling in BQL

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -1,0 +1,23 @@
+import { bqlToRuleset, rulesetToBql } from './bql';
+import { QueryBuilderConfig, RuleSet } from 'ngx-query-builder';
+
+describe('BQL named ruleset support', () => {
+  const config: QueryBuilderConfig = { fields: {} } as any;
+
+  it('should convert named ruleset to its name', () => {
+    const rs: RuleSet = { condition: 'and', rules: [{ field: 'a', operator: '=', value: 1 }], name: 'TEST' };
+    expect(rulesetToBql(rs, config)).toBe('TEST');
+  });
+
+  it('should parse named ruleset name', () => {
+    const rs = bqlToRuleset('TEST', config);
+    expect(rs.name).toBe('TEST');
+  });
+
+  it('should handle negated named ruleset', () => {
+    const rs = bqlToRuleset('!TEST', config);
+    expect(rs.name).toBe('TEST');
+    expect(rs.not).toBeTrue();
+    expect(rulesetToBql(rs, config)).toBe('!TEST');
+  });
+});


### PR DESCRIPTION
## Summary
- support named rulesets when parsing BQL
- emit ruleset names when converting rulesets to BQL
- test BQL named ruleset support

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875595a823c832195c7993197e9bc7d