### PR TITLE
Fix named ruleset parsing in BQL

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -1,5 +1,5 @@
 import { bqlToRuleset, rulesetToBql } from './bql';
-import { QueryBuilderConfig, RuleSet } from 'ngx-query-builder';
+import { QueryBuilderConfig, RuleSet, Rule } from 'ngx-query-builder';
 
 describe('BQL named ruleset support', () => {
   const config: QueryBuilderConfig = { fields: {} } as any;
@@ -19,5 +19,18 @@ describe('BQL named ruleset support', () => {
     expect(rs.name).toBe('TEST');
     expect(rs.not).toBeTrue();
     expect(rulesetToBql(rs, config)).toBe('!TEST');
+  });
+
+  it('should load named ruleset from config', () => {
+    const get = jasmine.createSpy('get').and.returnValue({
+      condition: 'and',
+      rules: [{ field: 'a', operator: '=', value: 1 }]
+    });
+    const cfg: QueryBuilderConfig = { fields: {}, getNamedRuleset: get } as any;
+    const rs = bqlToRuleset('TEST', cfg);
+    expect(get).toHaveBeenCalledWith('TEST');
+    expect(rs.name).toBe('TEST');
+    expect(rs.rules.length).toBe(1);
+    expect((rs.rules[0] as Rule).field).toBe('a');
   });
 });

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -81,7 +81,19 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig): RuleSet
     if (tok.value === '!') { consume(); const inner = parsePrimary(); inner.not = !inner.not; return inner; }
     if (tok.type === 'word' && isRulesetName(tok.value)) {
       consume();
-      return { condition: 'and', rules: [], name: tok.value };
+      const name = tok.value;
+      let stored: RuleSet | undefined;
+      if (config.getNamedRuleset) {
+        try {
+          stored = config.getNamedRuleset(name);
+        } catch {
+          stored = undefined;
+        }
+      }
+      if (stored) {
+        return { ...JSON.parse(JSON.stringify(stored)), name };
+      }
+      return { condition: 'and', rules: [], name };
     }
     // value or field rule
     const first = consume();


### PR DESCRIPTION
## Summary
- load previously stored ruleset when parsing named rules
- test config-based named ruleset lookup

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687568cc8c0483219d49893a6876d2b1