### PR TITLE
Add BQL validator

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -1,4 +1,4 @@
-import { bqlToRuleset, rulesetToBql } from './bql';
+import { bqlToRuleset, rulesetToBql, validateBql } from './bql';
 import { QueryBuilderConfig, RuleSet, Rule } from 'ngx-query-builder';
 
 describe('BQL named ruleset support', () => {
@@ -54,5 +54,30 @@ describe('BQL named ruleset support', () => {
     const cfg: QueryBuilderConfig = { fields: { a: { type: 'string' } } } as any;
     const rs = bqlToRuleset('(a=1)', cfg);
     expect(rulesetToBql(rs, cfg)).toBe('a=1');
+  });
+});
+
+describe('validateBql', () => {
+  const cfg: QueryBuilderConfig = {
+    fields: {
+      sign: { name: 'Sign', type: 'category', options: [{ name: 'Aries', value: 'aries' }] },
+      age: { name: 'Age', type: 'number', operators: ['=', '>'] }
+    }
+  } as any;
+
+  it('should accept valid category value', () => {
+    expect(validateBql('sign=aries', cfg)).toBeTrue();
+  });
+
+  it('should reject invalid category value', () => {
+    expect(validateBql('sign=taurus', cfg)).toBeFalse();
+  });
+
+  it('should reject invalid operator', () => {
+    expect(validateBql('age<10', cfg)).toBeFalse();
+  });
+
+  it('should return false on parse error', () => {
+    expect(validateBql('(age=1', cfg)).toBeFalse();
   });
 });

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -1,14 +1,14 @@
 <div class="query-input">
   <button pButton icon="pi pi-search" class="search-btn" (click)="clickSearch()"></button>
 
-  <div class="text" *ngIf="!editing" (click)="editing = true">
+  <div class="text" *ngIf="!editing" (click)="startEdit()">
     <span [ngClass]="{'placeholder': !query}">{{ query || placeholder }}</span>
   </div>
-  <input pInputText *ngIf="editing" [(ngModel)]="query" (keyup.enter)="acceptEdit()" />
+  <input pInputText *ngIf="editing" [(ngModel)]="query" (ngModelChange)="onQueryChange()" (keyup.enter)="acceptEdit()" [ngClass]="{'invalid': !validQuery}" />
 
   <div class="btn-group" *ngIf="editing">
     <button pButton icon="pi pi-times" (click)="cancelEdit()"></button>
-    <button pButton icon="pi pi-check" (click)="acceptEdit()"></button>
+    <button pButton icon="pi pi-check" (click)="acceptEdit()" [disabled]="!validQuery"></button>
   </div>
 </div>
 

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -50,6 +50,9 @@
     border: none;
     outline: none;
     padding: 4px;
+    &.invalid {
+      background: #ffe5e5;
+    }
   }
   
   .btn-group {

--- a/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DialogModule } from 'primeng/dialog';
@@ -7,7 +7,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { DropdownModule } from 'primeng/dropdown';
 import { TreeModule } from 'primeng/tree';
 import { QueryBuilderModule, QueryBuilderConfig, RuleSet, Rule } from 'ngx-query-builder';
-import { bqlToRuleset, rulesetToBql } from '../bql';
+import { bqlToRuleset, rulesetToBql, validateBql } from '../bql';
 import { MatDialog } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
@@ -28,7 +28,7 @@ import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
   styleUrls: ['./query-input.component.scss'],
   templateUrl: './query-input.component.html'
 })
-export class QueryInputComponent {
+export class QueryInputComponent implements OnInit {
   @Input() placeholder = 'Enter query';
   @Input() query = '';
   @Input() config?: QueryBuilderConfig;
@@ -43,8 +43,22 @@ export class QueryInputComponent {
   showBuilder = false;
   builderQuery: RuleSet = { condition: 'and', rules: [] };
   namedRulesets: Record<string, RuleSet> = {};
+  validQuery = true;
 
   constructor(private dialog: MatDialog) {}
+
+  ngOnInit(): void {
+    this.onQueryChange();
+  }
+
+  startEdit() {
+    this.editing = true;
+    this.onQueryChange();
+  }
+
+  onQueryChange() {
+    this.validQuery = validateBql(this.query, this.queryBuilderConfig);
+  }
 
   // Default configuration for the query builder
   defaultConfig: QueryBuilderConfig = {
@@ -109,6 +123,7 @@ export class QueryInputComponent {
 
   builderApplied(q: RuleSet) {
     this.query = this.stringifyQuery(q);
+    this.onQueryChange();
     this.queryChange.emit(this.query);
     this.showBuilder = false;
   }


### PR DESCRIPTION
## Summary
- validate BQL using QueryBuilder config rules
- disable invalid query entry in the QueryInput component
- mark invalid queries with a red background
- test new validator

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875721f380c83219c0bfc2ae879a592