### PR TITLE
Fix leftover token handling in BQL validation

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -80,4 +80,8 @@ describe('validateBql', () => {
   it('should return false on parse error', () => {
     expect(validateBql('(age=1', cfg)).toBeFalse();
   });
+
+  it('should reject queries with trailing text', () => {
+    expect(validateBql('sign=aries trailing', cfg)).toBeFalse();
+  });
 });

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -68,7 +68,9 @@ function parseValue(token: Token, field: string, config: QueryBuilderConfig): an
   return v;
 }
 
-export function bqlToRuleset(input: string, config: QueryBuilderConfig): RuleSet {
+export interface ParseInfo { index: number; length: number }
+
+export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: ParseInfo): RuleSet {
   const tokens = tokenize(input);
   let pos = 0;
   function peek() { return tokens[pos]; }
@@ -161,6 +163,7 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig): RuleSet
   function parseExpression(): RuleSet { return parseOr(); }
 
   const result = parseExpression();
+  if (info) { info.index = pos; info.length = tokens.length; }
   return result;
 }
 
@@ -301,7 +304,11 @@ function validateRuleset(rs: RuleSet, config: QueryBuilderConfig, parent?: RuleS
 
 export function validateBql(bql: string, config: QueryBuilderConfig): boolean {
   try {
-    const rs = bqlToRuleset(bql, config);
+    const info: ParseInfo = { index: 0, length: 0 };
+    const rs = bqlToRuleset(bql, config, info);
+    if (info.index !== info.length) {
+      return false;
+    }
     return validateRuleset(rs, config);
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- expose parsing info from `bqlToRuleset`
- check for leftover tokens in `validateBql`
- add regression test for trailing text

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785bd128e08321b01e947224bf4def