### PR TITLE
Fix residual token detection in BQL validator

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -84,4 +84,8 @@ describe('validateBql', () => {
   it('should reject queries with trailing text', () => {
     expect(validateBql('sign=aries trailing', cfg)).toBeFalse();
   });
+
+  it('should reject queries with dangling operator', () => {
+    expect(validateBql('sign=aries &', cfg)).toBeFalse();
+  });
 });

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -78,7 +78,7 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
 
   function parsePrimary(): RuleSet {
     const tok = peek();
-    if (!tok) return { condition: 'and', rules: [] };
+    if (!tok) throw new Error('Unexpected end of input');
     if (tok.value === '(') {
       consume();
       const expr = parseExpression();
@@ -104,13 +104,17 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
       return { condition: 'and', rules: [], name };
     }
     // value or field rule
+    if (tok.type !== 'word' && tok.type !== 'string') {
+      throw new Error('Unexpected token');
+    }
+
     const first = consume();
     const next = peek();
-    if (next && next.type === 'operator' || (next && next.type === 'word' && isAlphaOperator(next.value))) {
+    if (next && (next.type === 'operator' || (next.type === 'word' && isAlphaOperator(next.value)))) {
       const opTok = consume();
       const valTok = consume();
       if (!valTok) {
-        return { condition: 'and', rules: [] };
+        throw new Error('Unexpected end of input');
       }
       const field = first.value;
       const operator = opTok.type === 'word' ? opTok.value.toLowerCase() : opTok.value;


### PR DESCRIPTION
## Summary
- throw errors when the parser encounters unexpected tokens or the end of input
- add a unit test checking for dangling operator tokens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687860a996e08321b1946823f23a5a1c