### PR TITLE
Fix BQL validation for parentheses and named rulesets

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -88,4 +88,12 @@ describe('validateBql', () => {
   it('should reject queries with dangling operator', () => {
     expect(validateBql('sign=aries &', cfg)).toBeFalse();
   });
+
+  it('should reject unbalanced parentheses', () => {
+    expect(validateBql('(xx', cfg)).toBeFalse();
+  });
+
+  it('should reject unknown named rulesets', () => {
+    expect(validateBql('ABC', cfg)).toBeFalse();
+  });
 });


### PR DESCRIPTION
## Summary
- enforce closing paren in BQL parser
- validate named rulesets exist during BQL validation
- add tests for unbalanced parens and unknown names

## Testing
- `pnpm exec ng test --watch=false` *(fails: Command "ng" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786c64ddf88321bbb8a664869d0b1e