### PR TITLE
Fix negated named ruleset handling

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -133,6 +133,9 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
     if (peek() && peek().value === '!') {
       consume();
       const rs = parseUnary();
+      if (rs.name) {
+        return { condition: 'and', rules: [rs], not: true };
+      }
       rs.not = !rs.not;
       return rs;
     }
@@ -206,6 +209,12 @@ export function rulesetToBql(rs: RuleSet, config: QueryBuilderConfig): string {
   function rulesetString(r: RuleSet, parent?: 'and' | 'or'): string {
     if (r.name) {
       return r.not ? `!${r.name}` : r.name;
+    }
+    if (r.not && r.rules.length === 1 && !isRule(r.rules[0])) {
+      const child = r.rules[0] as RuleSet;
+      if (child.name && !child.not) {
+        return `!${child.name}`;
+      }
     }
     if (!r.not && r.rules.length === 1) {
       const only = r.rules[0];


### PR DESCRIPTION
## Summary
- treat NOT operator before named rulesets as wrapping them rather than modifying them directly
- stringify NOT of named ruleset without surrounding parentheses

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787861ecd88321a8a8c96f5d910a0b