### PR TITLE
Fix negated named ruleset retrieval

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -34,6 +34,21 @@ describe('BQL named ruleset support', () => {
     expect((rs.rules[0] as Rule).field).toBe('a');
   });
 
+  it('should load negated named ruleset from config', () => {
+    const get = jasmine.createSpy('get').and.returnValue({
+      condition: 'and',
+      rules: [{ field: 'a', operator: '=', value: 1 }]
+    });
+    const cfg: QueryBuilderConfig = { fields: {}, getNamedRuleset: get } as any;
+    const rs = bqlToRuleset('!TEST', cfg);
+    expect(get).toHaveBeenCalledWith('TEST');
+    expect(rs.not).toBeTrue();
+    expect(rs.rules.length).toBe(1);
+    const child = rs.rules[0] as RuleSet;
+    expect(child.name).toBe('TEST');
+    expect((child.rules[0] as Rule).field).toBe('a');
+  });
+
   it('should create rulesets for parentheses', () => {
     const cfg: QueryBuilderConfig = { fields: { a: { type: 'string' }, b: { type: 'string' } } } as any;
     const rs = bqlToRuleset('(a=1) & (b=2)', cfg);

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -134,7 +134,16 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
       consume();
       const rs = parseUnary();
       if (rs.name) {
-        return { condition: 'and', rules: [rs], not: true };
+        let stored: RuleSet | undefined;
+        if (config.getNamedRuleset) {
+          try {
+            stored = config.getNamedRuleset(rs.name);
+          } catch {
+            stored = undefined;
+          }
+        }
+        const child = stored ? { ...JSON.parse(JSON.stringify(stored)), name: rs.name } : rs;
+        return { condition: 'and', rules: [child], not: true };
       }
       rs.not = !rs.not;
       return rs;


### PR DESCRIPTION
## Summary
- ensure `!ABC` pulls in the `ABC` rules when parsing
- test negated named ruleset retrieval

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787d3a1f0c832188cba321bbc7bea9