### PR TITLE
Fix NOT toggle for single rule rulesets

### DIFF
--- a/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -114,7 +114,7 @@
   <ng-template #defaultSwitchGroup>
     <div [ngClass]="getClassNames('switchGroup', 'transition')" *ngIf="data"
          (mouseenter)="hoveringSwitchGroup = true" (mouseleave)="hoveringSwitchGroup = false">
-      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (data.not || (hoveringSwitchGroup && data.rules.length !== 1))">
+      <div [ngClass]="getClassNames('switchControl')" *ngIf="allowNot && (data.not || hoveringSwitchGroup)">
         <input type="checkbox" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.not"
                (ngModelChange)="changeNot($event)" [disabled]="disabled" />
         <label (click)="changeNot(!data.not)" [ngClass]="getClassNames('switchLabel')">


### PR DESCRIPTION
## Summary
- show NOT checkbox when hovering the condition box for single-rule rulesets

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687881af7f988321ad6510c3997b27ca