### PR TITLE
Fix OR parsing

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -65,6 +65,19 @@ describe('BQL named ruleset support', () => {
     expect((rs.rules[1] as RuleSet).name).toBe('TWO');
   });
 
+  it('should flatten simple OR queries into a single ruleset', () => {
+    const cfg: QueryBuilderConfig = { fields: { fname: { type: 'string' } } } as any;
+    const rs = bqlToRuleset('fname=bill | fname=john', cfg);
+    expect(rs.condition).toBe('or');
+    expect(rs.rules.length).toBe(2);
+    const r1 = rs.rules[0] as Rule;
+    const r2 = rs.rules[1] as Rule;
+    expect(r1.field).toBe('fname');
+    expect(r1.value).toBe('bill');
+    expect(r2.field).toBe('fname');
+    expect(r2.value).toBe('john');
+  });
+
   it('should omit redundant parentheses when stringifying', () => {
     const cfg: QueryBuilderConfig = { fields: { a: { type: 'string' } } } as any;
     const rs = bqlToRuleset('(a=1)', cfg);

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -164,6 +164,22 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
       left.rules.push(...right.rules);
       return left;
     }
+    // flatten single-rule AND children when merging OR conditions
+    if (
+      cond === 'or' &&
+      left.condition === 'and' &&
+      right.condition === 'and' &&
+      left.rules.length === 1 &&
+      right.rules.length === 1 &&
+      !left.not &&
+      !right.not &&
+      !left.name &&
+      !right.name &&
+      !left.isChild &&
+      !right.isChild
+    ) {
+      return { condition: 'or', rules: [left.rules[0], right.rules[0]] };
+    }
     return { condition: cond, rules: [left, right] };
   }
 


### PR DESCRIPTION
## Summary
- flatten simple OR merges in `bqlToRuleset`
- test `bqlToRuleset` OR parsing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5bfe588c8321a486554134b999ca