### PR TITLE
Fix pipeline for pnpm v9 lockfile

### DIFF
--- a/.github/workflows/pnpm-build.yml
+++ b/.github/workflows/pnpm-build.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: true
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- use pnpm 9 in workflow to match lockfile

## Testing
- `pnpm build` *(fails: ng: not found)*
- `pnpm install --frozen-lockfile` *(fails: Forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_687e6336db088321bc47318fbace25ad