### PR TITLE
Fix tests for demo and ruleset parsing

### DIFF
--- a/projects/popup-demo/src/app/app.component.spec.ts
+++ b/projects/popup-demo/src/app/app.component.spec.ts
@@ -24,6 +24,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, popup-demo');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Popup NGX Query Builder Demo');
   });
 });

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -158,16 +158,18 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
       consume();
       const rs = parseUnary();
       if (rs.name) {
-        let stored: RuleSet | undefined;
         if (config.getNamedRuleset) {
+          let stored: RuleSet | undefined;
           try {
             stored = config.getNamedRuleset(rs.name);
           } catch {
             stored = undefined;
           }
+          const child = stored ? { ...JSON.parse(JSON.stringify(stored)), name: rs.name } : rs;
+          return { condition: 'and', rules: [child], not: true };
         }
-        const child = stored ? { ...JSON.parse(JSON.stringify(stored)), name: rs.name } : rs;
-        return { condition: 'and', rules: [child], not: true };
+        rs.not = !rs.not;
+        return rs;
       }
       rs.not = !rs.not;
       return rs;


### PR DESCRIPTION
## Summary
- support negated named rulesets without a config lookup
- update demo test to match displayed title

## Testing
- `pnpm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7a80086483219bf9f387a1bd0421