### PR TITLE
Improve demo ruleset handling

### DIFF
--- a/projects/popup-demo/src/app/app.component.html
+++ b/projects/popup-demo/src/app/app.component.html
@@ -3,20 +3,20 @@
   <p>This is a demo of the popup query builder component. Click the search button to open the query builder.</p>
   
   <div class="query-section">
-    <h3>Query Input Component</h3>
-    <lib-query-input 
+    <h3>BQL</h3>
+    <lib-query-input
       [(query)]="currentQuery"
       (queryChange)="onQueryChange($event)"
-      placeholder="Click search to build a query...">
+      placeholder="BQL">
     </lib-query-input>
   </div>
-  
-  <div class="result-section" *ngIf="currentQuery">
-    <h3>Current Query</h3>
-    <textarea 
+
+  <div class="result-section">
+    <h3>Ruleset</h3>
+    <textarea
       class="query-output"
-      [value]="getFormattedQuery()"
-      readonly>
+      [(ngModel)]="rulesetJson"
+      (ngModelChange)="onRulesetChange($event)">
     </textarea>
   </div>
 </div>

--- a/projects/popup-demo/src/app/app.component.ts
+++ b/projects/popup-demo/src/app/app.component.ts
@@ -1,24 +1,43 @@
-import { Component } from '@angular/core';
-import { QueryInputComponent } from 'popup-ngx-query-builder';
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { QueryInputComponent, bqlToRuleset, rulesetToBql } from 'popup-ngx-query-builder';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [QueryInputComponent, CommonModule],
+  imports: [QueryInputComponent, CommonModule, FormsModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements AfterViewInit {
   title = 'popup-demo';
   currentQuery = '';
+  rulesetJson = '';
+
+  @ViewChild(QueryInputComponent) queryInput!: QueryInputComponent;
+
+  ngAfterViewInit(): void {
+    this.onQueryChange(this.currentQuery);
+  }
 
   onQueryChange(query: string) {
     this.currentQuery = query;
-    console.log('Query changed:', query);
+    try {
+      const rs = bqlToRuleset(query, this.queryInput.queryBuilderConfig);
+      this.rulesetJson = JSON.stringify(rs, null, 2);
+    } catch {
+      this.rulesetJson = '';
+    }
   }
 
-  getFormattedQuery(): string {
-    return this.currentQuery;
+  onRulesetChange(value: string) {
+    this.rulesetJson = value;
+    try {
+      const rs = JSON.parse(value);
+      this.currentQuery = rulesetToBql(rs, this.queryInput.queryBuilderConfig);
+    } catch {
+      // ignore parse errors
+    }
   }
 }


### PR DESCRIPTION
## Summary
- rename Query Input header to BQL
- show the parsed ruleset JSON in an editable box
- sync ruleset edits back to the BQL input

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e80371a8c832187c490259939d67c