### PR TITLE
Fix IN operator handling

### DIFF
--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -116,6 +116,17 @@ describe('BQL named ruleset support', () => {
     expect(r.operator).toBe('!like');
     expect(rulesetToBql(rs, cfg)).toBe('fname !LIKE bob');
   });
+
+  it('should parse and stringify IN operator', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { sign: { type: 'string', operators: ['in'] } }
+    } as any;
+    const rs = bqlToRuleset('sign IN (aries,taurus)', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(Array.isArray(r.value)).toBeTrue();
+    expect(r.value.length).toBe(2);
+    expect(rulesetToBql(rs, cfg)).toBe('sign IN (aries,taurus)');
+  });
 });
 
 describe('validateBql', () => {
@@ -179,5 +190,19 @@ describe('validateBql', () => {
       fields: { fname: { name: 'First', type: 'string', operators: ['!like'] } }
     } as any;
     expect(validateBql('fname !LIKE bob', cfg4)).toBeTrue();
+  });
+
+  it('should accept IN operator', () => {
+    const cfg5: QueryBuilderConfig = {
+      fields: { sign: { name: 'Sign', type: 'category', options: [{ name: 'Aries', value: 'aries' }, { name: 'Taurus', value: 'taurus' }], operators: ['in'] } }
+    } as any;
+    expect(validateBql('sign IN (aries,taurus)', cfg5)).toBeTrue();
+  });
+
+  it('should reject invalid value in IN operator', () => {
+    const cfg5: QueryBuilderConfig = {
+      fields: { sign: { name: 'Sign', type: 'category', options: [{ name: 'Aries', value: 'aries' }], operators: ['in'] } }
+    } as any;
+    expect(validateBql('sign IN (aries,taurus)', cfg5)).toBeFalse();
   });
 });

--- a/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -127,6 +127,32 @@ describe('BQL named ruleset support', () => {
     expect(r.value.length).toBe(2);
     expect(rulesetToBql(rs, cfg)).toBe('sign IN (aries,taurus)');
   });
+
+  it('should parse IN operator with quoted value', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { sign: { type: 'string', operators: ['in'] } }
+    } as any;
+    const rs = bqlToRuleset('sign IN ("abc")', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(Array.isArray(r.value)).toBeTrue();
+    expect(r.value).toEqual(['abc']);
+  });
+
+  it('should parse IN operator with whitespace', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { sign: { type: 'string', operators: ['in'] } }
+    } as any;
+    const rs = bqlToRuleset('sign IN (aries,   taurus, gemini)', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(r.value).toEqual(['aries', 'taurus', 'gemini']);
+  });
+
+  it('should throw on IN operator with no values', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { sign: { type: 'string', operators: ['in'] } }
+    } as any;
+    expect(() => bqlToRuleset('sign IN ()', cfg)).toThrow();
+  });
 });
 
 describe('validateBql', () => {
@@ -197,6 +223,27 @@ describe('validateBql', () => {
       fields: { sign: { name: 'Sign', type: 'category', options: [{ name: 'Aries', value: 'aries' }, { name: 'Taurus', value: 'taurus' }], operators: ['in'] } }
     } as any;
     expect(validateBql('sign IN (aries,taurus)', cfg5)).toBeTrue();
+  });
+
+  it('should accept IN operator with whitespace', () => {
+    const cfg5: QueryBuilderConfig = {
+      fields: { sign: { name: 'Sign', type: 'category', options: [{ name: 'Aries', value: 'aries' }, { name: 'Taurus', value: 'taurus' }, { name: 'Gemini', value: 'gemini' }], operators: ['in'] } }
+    } as any;
+    expect(validateBql('sign IN (aries,   taurus, gemini)', cfg5)).toBeTrue();
+  });
+
+  it('should accept IN operator with quoted value', () => {
+    const cfg5: QueryBuilderConfig = {
+      fields: { sign: { name: 'Sign', type: 'category', options: [{ name: 'Abc', value: 'abc' }], operators: ['in'] } }
+    } as any;
+    expect(validateBql('sign IN ("abc")', cfg5)).toBeTrue();
+  });
+
+  it('should reject IN operator with no values', () => {
+    const cfg5: QueryBuilderConfig = {
+      fields: { sign: { name: 'Sign', type: 'category', options: [], operators: ['in'] } }
+    } as any;
+    expect(validateBql('sign IN ()', cfg5)).toBeFalse();
   });
 
   it('should reject invalid value in IN operator', () => {

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -76,7 +76,7 @@ function tokenize(input: string): Token[] {
       i = j + 1; continue;
     }
     let j = i;
-    while (j < input.length && !/\s|\(|\)|!|&|\||=|<|>/.test(input[j])) j++;
+    while (j < input.length && !/\s|\(|\)|!|&|\||=|<|>|,/.test(input[j])) j++;
     const word = input.slice(i, j);
     tokens.push({ type: 'word', value: word });
     i = j;

--- a/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -180,6 +180,9 @@ export function bqlToRuleset(input: string, config: QueryBuilderConfig, info?: P
         }
         if (!peek() || peek().value !== ')') { throw new Error('Missing closing parenthesis'); }
         consume();
+        if (values.length === 0) {
+          throw new Error('IN requires at least one value');
+        }
         return { condition: 'and', rules: [{ field, operator, value: values }] };
       }
 
@@ -363,8 +366,10 @@ function validateRule(rule: Rule, parent: RuleSet, config: QueryBuilderConfig): 
     return false;
   }
 
-  if ((rule.operator === 'in' || rule.operator === 'not in') && !Array.isArray(rule.value)) {
-    return false;
+  if (rule.operator === 'in' || rule.operator === 'not in') {
+    if (!Array.isArray(rule.value) || rule.value.length === 0) {
+      return false;
+    }
   }
 
   let allowedValues: any[] | undefined;


### PR DESCRIPTION
## Summary
- handle comma tokens in BQL tokenizer
- support `IN`/`NOT IN` parsing and stringifying
- ensure arrays are produced for `IN` operations
- validate array contents for `IN` values
- add unit tests for `IN` functionality

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb057cee08321a3737ccfd9430c0c